### PR TITLE
[Hacktoberfest] Add HTML entity so it can be easier to copy to the web code

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,14 @@
         </div>
       </div>
 
-      <div class="bits-text">{{bitstring}} = {{parseInt(bitstring, 2)}}</div>
+      <div class="bits-text">{{bitstring}} = {{parseInt(bitstring, 2)}} {{htmlEntity}}</div>
 
       <a class="mode-switch" href="/words">Multiple Characters Mode</a>
       <a class="mode-switch" href="/stacked">Stacked Drawing Mode</a>
+      <span class="mode-switch">
+        <input type="checkbox" v-model="module.withHtmlEntity" name="with-html-entity" />
+        <label for="with-html-entity">With HTML Entity</label>
+      </span>
     </main>
 
     <style scoped>
@@ -117,6 +121,7 @@
         el: "main",
         data: {
           message: "a",
+          withHtmlEntity: false
         },
         computed: {
           bits() {
@@ -131,6 +136,10 @@
           bitstring() {
             return this.bits.join("")
           },
+
+          htmlEntity() {
+            return this.withHtmlEntity ? ` &#x{this.message.charCodeAt(0).toString('hex')}` : ''
+          }
         },
         methods: {
           /** @param {number} bit */

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       <a class="mode-switch" href="/words">Multiple Characters Mode</a>
       <a class="mode-switch" href="/stacked">Stacked Drawing Mode</a>
       <span class="mode-switch">
-        <input type="checkbox" v-model="module.withHtmlEntity" name="with-html-entity" />
+        <input type="checkbox" v-model="withHtmlEntity" id="with-html-entity" />
         <label for="with-html-entity">With HTML Entity</label>
       </span>
     </main>
@@ -138,7 +138,9 @@
           },
 
           htmlEntity() {
-            return this.withHtmlEntity ? ` &#x{this.message.charCodeAt(0).toString('hex')}` : ''
+            return this.withHtmlEntity
+				? ` = &#x${this.message.charCodeAt(0).toString('16')};`
+				: ''
           }
         },
         methods: {


### PR DESCRIPTION
What changes?:
- Add an HTML entity code behind the base-10 number of the character so it can be easier to copy to the web code
- Add a checkbox to toggle displaying HTML entity.

![image](https://github.com/heypoom/unicode-sprite/assets/3356814/12304ecf-2137-4665-8e0f-eacba66f3c19)
